### PR TITLE
GPIO Pinning for ELAN1200 - ASUS FX502VM-AH51

### DIFF
--- a/.maciasl
+++ b/.maciasl
@@ -4,3 +4,4 @@
 [Windows] Windows 10 Patch				Windows/Windows_10.txt
 [Controllers] I2C Controllers [SKL]		Controllers/controllers.txt
 [GPIO] GPIO Controller Enable [SKL+]	GPIO/status.txt
+[GPIO] GPIO Pinning - ELAN1200 (ASUS FX502VM) GPIO/gpio_pinning_elan1200_asus-fx502vm.txt

--- a/GPIO/gpio_pinning_elan1200.txt
+++ b/GPIO/gpio_pinning_elan1200.txt
@@ -1,0 +1,21 @@
+# GPIO Pinning for ELAN1200 by HackinDoge
+# Confirmed working on ASUS FX502VM-AH51
+
+into device label ETPD insert begin
+
+Name (SBFG, ResourceTemplate ()\n
+    {\n
+        GpioInt (Level, ActiveLow, ExclusiveAndWake, PullDefault, 0x0000,\n
+            "\\_SB.PCI0.GPI0", 0x00, ResourceConsumer, ,
+            )\n
+            {   // Pin list\n
+                0x47\n
+            }\n
+    })\n
+end;
+
+into method label _CRS parent_label ETPD replace_content begin
+
+Return (ConcatenateResTemplate (SBFB, SBFG))
+
+end;

--- a/GPIO/gpio_pinning_elan1200.txt
+++ b/GPIO/gpio_pinning_elan1200.txt
@@ -6,7 +6,7 @@ into device label ETPD insert begin
 Name (SBFG, ResourceTemplate ()\n
     {\n
         GpioInt (Level, ActiveLow, ExclusiveAndWake, PullDefault, 0x0000,\n
-            "\\_SB.PCI0.GPI0", 0x00, ResourceConsumer, ,
+            "\\_SB.PCI0.GPI0", 0x00, ResourceConsumer, ,\n
             )\n
             {   // Pin list\n
                 0x47\n

--- a/GPIO/gpio_pinning_elan1200_asus-fx502vm.txt
+++ b/GPIO/gpio_pinning_elan1200_asus-fx502vm.txt
@@ -12,6 +12,7 @@ Name (SBFG, ResourceTemplate ()\n
                 0x47\n
             }\n
     })\n
+    
 end;
 
 into method label _CRS parent_label ETPD replace_content begin


### PR DESCRIPTION
Updated my ASUS FX502VM-AH51 to VoodooI2C v2 up from a custom v1.0.4 with MacForceOne's ELAN1200 patch.  At first I wasn't getting any response from the trackpad, despite it being recognized in IORegistryExplorer and having applied the preliminary DSDT patches found in the Installation Guide.

I was about to give up and rollback to the working v1.0.4 until I went back and read through the GPIO Pinning guide.  After discovering that my trackpad was unpinned, I followed the guide to completion, which resulted in a working trackpad!  **This patch contains the DSDT code which completed the activation of my ELAN1200 trackpad using VoodooI2C v2.  It does not contain any of the preliminary patches (Controllers/controllers.txt, GPIO/status.txt).**

Clicking + Dragging for highlighting, moving windows, etc, is buggy, but the two-finger scrolling is a welcome addition, as well as the ability to use the native Trackpad settings pane.